### PR TITLE
Layers : Set switch to call the theme color instead of the primary color...

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -78,7 +78,7 @@
         <item name="android:colorPrimary">@color/dialer_theme_color</item>
         <item name="android:colorPrimaryDark">@color/dialer_theme_color_dark</item>
         <item name="dialpad_key_button_touch_tint">@color/dialer_dialpad_touch_tint</item>
-        <item name="android:colorControlActivated">@color/dialer_theme_color</item>
+        <item name="android:colorControlActivated">@color/dialtacts_theme_color</item>
     </style>
 
     <!-- Action bar overflow menu icon. -->


### PR DESCRIPTION
In original commit the dialtacts_theme_color is set at 3 different places. I don't think there is a need to do that.

..., not every themer is lazy to just use 2 colors.

Swtiches now call dialtacts_theme_color instead of the dialer_theme_color.

Signed-off-by: CallMeAldy aldrin.holmes20@gmail.com

Conflicts:
    res/values/styles.xml
